### PR TITLE
Automatically copy output to clipboard

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: Lint
 on: [push, pull_request]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev", "pypy3"]
+        python-version: ["pypy3", "3.6", "3.7", "3.8", "3.9", "3.10-dev"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
           # Include new variables for Codecov

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![GitHub Actions status](https://github.com/hugovk/slackabet/workflows/Test/badge.svg)](https://github.com/hugovk/slackabet/actions)
 [![codecov](https://codecov.io/gh/hugovk/slackabet/branch/main/graph/badge.svg)](https://codecov.io/gh/hugovk/slackabet)
 [![GitHub](https://img.shields.io/github/license/hugovk/slackabet.svg)](LICENSE.txt)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4071428.svg)](https://doi.org/10.5281/zenodo.4071428)
 [![Code style: Black](https://img.shields.io/badge/code%20style-Black-000000.svg)](https://github.com/psf/black)
 
 Convert text into

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     zip_safe=True,
     use_scm_version={"local_scheme": local_scheme},
     setup_requires=["setuptools_scm"],
+    install_requires=['pyperclip; platform_system != "Linux"'],
     extras_require={"tests": ["hypothesis-auto", "pytest", "pytest-cov"]},
     python_requires=">=3.6",
     project_urls={

--- a/src/slackabet/__init__.py
+++ b/src/slackabet/__init__.py
@@ -31,6 +31,3 @@ def slackabet(text: str, colour: str = "white") -> str:
             new += c
 
     return new
-
-
-# End of file

--- a/src/slackabet/cli.py
+++ b/src/slackabet/cli.py
@@ -6,6 +6,11 @@ import argparse
 
 import slackabet
 
+try:
+    import pyperclip
+except ImportError:
+    pyperclip = None
+
 
 def main():
     parser = argparse.ArgumentParser()
@@ -18,6 +23,9 @@ def main():
     parser.add_argument(
         "-r", "--random", action="store_true", help="Randomly coloured letters"
     )
+    parser.add_argument(
+        "--no-copy", action="store_true", help="Do not copy to clipboard"
+    )
     args = parser.parse_args()
 
     colour = "white"
@@ -28,7 +36,11 @@ def main():
     elif args.random:
         colour = "random"
 
-    print(slackabet.slackabet(args.text, colour))
+    out = slackabet.slackabet(args.text, colour)
+    print(out)
+    if pyperclip and not args.no_copy:
+        pyperclip.copy(out)
+        print("Copied!")
 
 
 if __name__ == "__main__":

--- a/tests/test_slackabet.py
+++ b/tests/test_slackabet.py
@@ -1,11 +1,10 @@
+import pytest
 from hypothesis_auto import auto_pytest_magic
 
 import slackabet
 
 
-def test_something():
-    # Arrange
-
+def test_slackabet_default():
     # Act
     text = slackabet.slackabet("123ABCabc@!#?")
 
@@ -21,22 +20,28 @@ def test_something():
     )
 
 
-def test_something_else():
-    # Arrange
-
+@pytest.mark.parametrize(
+    ("test_colour", "expected"),
+    [
+        ("yellow", ":alphabet-yellow-A:"),
+        ("white", ":alphabet-white-A:"),
+    ],
+)
+def test_slackabet_colour(test_colour: str, expected: str):
     # Act
-    text = slackabet.slackabet("123ABCabc@!#?", colour="yellow")
+    text = slackabet.slackabet("A", colour=test_colour)
 
     # Assert
-    assert (
-        text == "123"
-        ":alphabet-yellow-A::alphabet-yellow-B::alphabet-yellow-C:"
-        ":alphabet-yellow-a::alphabet-yellow-b::alphabet-yellow-c:"
-        ":alphabet-yellow-at:"
-        ":alphabet-yellow-exclamation:"
-        ":alphabet-yellow-hash:"
-        ":alphabet-yellow-question:"
-    )
+    assert text == expected
+
+
+def test_slackabet_random():
+    # Act
+    text = slackabet.slackabet("A", colour="random")
+
+    # Assert
+    assert ":alphabet-" in text
+    assert "-A:" in text
 
 
 auto_pytest_magic(slackabet.slackabet)


### PR DESCRIPTION
Unless `--no-copy`, or Linux, where pyperclip no longer works.