### PR TITLE
Allow multiword CLI text input without requiring wrapping in quotes

### DIFF
--- a/src/slackabet/cli.py
+++ b/src/slackabet/cli.py
@@ -14,7 +14,7 @@ except ImportError:
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("text", help="Text to convert to emoji")
+    parser.add_argument("text", nargs="+", help="Text to convert to emoji")
     parser.add_argument(
         "-V", "--version", action="version", version=f"%(prog)s {slackabet.__version__}"
     )
@@ -27,6 +27,7 @@ def main():
         "--no-copy", action="store_true", help="Do not copy to clipboard"
     )
     args = parser.parse_args()
+    args.text = " ".join(args.text)
 
     colour = "white"
     if args.white:


### PR DESCRIPTION
# Before

```console
$ slackabet "a b c"
:alphabet-white-a: :alphabet-white-b: :alphabet-white-c:
Copied!
$ slackabet a b c
usage: slackabet [-h] [-V] [-w] [-y] [-r] [--no-copy] text
slackabet: error: unrecognized arguments: b c
```

# After

```console
$ slackabet "a b c"
:alphabet-white-a: :alphabet-white-b: :alphabet-white-c:
Copied!
$ slackabet a b c
:alphabet-white-a: :alphabet-white-b: :alphabet-white-c:
Copied!
```

# Note

Use quote if whitespace is important.

```console
$ slackabet a    b    c
:alphabet-white-a: :alphabet-white-b: :alphabet-white-c:
Copied!
$ slackabet "a    b    c"
:alphabet-white-a:    :alphabet-white-b:    :alphabet-white-c:
Copied!
```
