### PR TITLE
Speedup: replace slow pkg_resources with importlib_metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -35,7 +35,7 @@ repos:
       - id: python-check-blanket-noqa
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -50,7 +50,7 @@ repos:
       - id: setup-cfg-fmt
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.920
+    rev: v0.930
     hooks:
       - id: mypy
         additional_dependencies: [types-setuptools]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
+    importlib-metadata;python_version < '3.8'
     pyperclip;platform_system != "Linux"
 python_requires = >=3.7
 package_dir = =src

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 
-def local_scheme(version) -> str:
+def local_scheme(version: str) -> str:
     """Skip the local version (eg. +xyz of 0.6.1.dev4+gdf99fe2)
     to be able to upload to Test PyPI"""
     return ""

--- a/src/slackabet/__init__.py
+++ b/src/slackabet/__init__.py
@@ -1,8 +1,13 @@
 import random
 
-import pkg_resources
+try:
+    # Python 3.8+
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    # Python 3.7 and lower
+    import importlib_metadata  # type: ignore
 
-__version__: str = pkg_resources.get_distribution(__name__).version
+__version__: str = importlib_metadata.version(__name__)
 
 
 COLOURS = ["white", "yellow"]

--- a/src/slackabet/cli.py
+++ b/src/slackabet/cli.py
@@ -7,12 +7,12 @@ import argparse
 import slackabet
 
 try:
-    import pyperclip
+    import pyperclip  # type: ignore
 except ImportError:
     pyperclip = None
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("text", nargs="+", help="Text to convert to emoji")
     parser.add_argument(

--- a/tests/test_slackabet.py
+++ b/tests/test_slackabet.py
@@ -1,10 +1,10 @@
 import pytest
-from hypothesis_auto import auto_pytest_magic
+from hypothesis_auto import auto_pytest_magic  # type: ignore[import]
 
 import slackabet
 
 
-def test_slackabet_default():
+def test_slackabet_default() -> None:
     # Act
     text = slackabet.slackabet("123ABCabc@!#?")
 
@@ -27,7 +27,7 @@ def test_slackabet_default():
         ("white", ":alphabet-white-A:"),
     ],
 )
-def test_slackabet_colour(test_colour: str, expected: str):
+def test_slackabet_colour(test_colour: str, expected: str) -> None:
     # Act
     text = slackabet.slackabet("A", colour=test_colour)
 
@@ -35,7 +35,7 @@ def test_slackabet_colour(test_colour: str, expected: str):
     assert text == expected
 
 
-def test_slackabet_random():
+def test_slackabet_random() -> None:
     # Act
     text = slackabet.slackabet("A", colour="random")
 
@@ -44,7 +44,7 @@ def test_slackabet_random():
     assert "-A:" in text
 
 
-def test_slackabet_words():
+def test_slackabet_words() -> None:
     # Act
     text = slackabet.slackabet("hello there", colour="words")
 


### PR DESCRIPTION
```sh
python -X importtime -c 'import slackabet; print(slackabet.__version__)' 2> import.log
python -m pip install tuna
tuna import.log
```

# Before

![image](https://user-images.githubusercontent.com/1324225/148635754-6b945749-55d7-4d33-ab7b-1c434a14e3a2.png)

# After

![image](https://user-images.githubusercontent.com/1324225/148635773-8b985e28-c8c3-4362-9c27-21c3fe636e92.png)

