### PR TITLE
Autolabel pre-commit PRs with 'changelog: skip'

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -22,6 +22,11 @@ categories:
 exclude-labels:
   - "changelog: skip"
 
+autolabeler:
+  - label: "changelog: skip"
+    branch:
+      - "/pre-commit-ci-update-config/"
+
 template: |
   $CHANGES
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,11 +5,27 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target:
+  #   types: [opened, reopened, synchronize]
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   update_release_draft:
     if: github.repository_owner == 'hugovk'
+    permissions:
+      # write permission is required to create a GitHub Release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       # Drafts your next release notes as pull requests are merged into "main"


### PR DESCRIPTION
Upstream request: https://github.com/pre-commit-ci/issues/issues/24

In the meantime, we can use Release Drafter to add "changelog: skip" to pre-commit CI's update PRs, as they don't need to be in the release notes.

https://github.com/release-drafter/release-drafter#autolabeler 

