### PR TITLE
Add 'id-token: write' permission for OIDC publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,10 @@ jobs:
     if: github.repository_owner == 'hugovk'
     runs-on: ubuntu-latest
 
+    permissions:
+      # IMPORTANT: this permission is mandatory for OIDC publishing
+      id-token: write
+
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Missing from https://github.com/hugovk/slackabet/pull/26.