### PR TITLE
Add support for Python 3.12, drop EOL 3.7

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max_line_length = 88
+max-line-length = 88

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,49 +2,71 @@ name: Deploy
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+    tags: ["*"]
+  pull_request:
+    branches: [main]
   release:
     types:
       - published
   workflow_dispatch:
 
-jobs:
-  deploy:
-    if: github.repository_owner == 'hugovk'
-    runs-on: ubuntu-latest
+permissions:
+  contents: read
 
-    permissions:
-      # IMPORTANT: this permission is mandatory for OIDC publishing
-      id-token: write
+jobs:
+  # Always build & lint package.
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - uses: hynek/build-and-inspect-python-package@v1
+
+  # Upload to Test PyPI on every commit on main.
+  release-test-pypi:
+    name: Publish in-dev package to test.pypi.org
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v3
         with:
-          python-version: "3.x"
-          cache: pip
-          cache-dependency-path: pyproject.toml
+          name: Packages
+          path: dist
 
-      - name: Install dependencies
-        run: |
-          python -m pip install -U pip
-          python -m pip install -U build twine wheel
-
-      - name: Build package
-        run: |
-          python -m build
-          twine check --strict dist/*
-
-      - name: Publish package to PyPI
-        if: github.event.action == 'published'
-        uses: pypa/gh-action-pypi-publish@unstable/v1
-
-      - name: Publish package to TestPyPI
-        uses: pypa/gh-action-pypi-publish@unstable/v1
+      - name: Upload package to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+
+  # Upload to real PyPI on GitHub Releases.
+  release-pypi:
+    name: Publish released package to pypi.org
+    if: github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: build-package
+
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
+    steps:
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v3
+        with:
+          name: Packages
+          path: dist
+
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Lint
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/require-pr-label.yml
+++ b/.github/workflows/require-pr-label.yml
@@ -8,8 +8,11 @@ jobs:
   label:
     runs-on: ubuntu-latest
 
+    permissions:
+      issues: write
+
     steps:
-      - uses: mheap/github-action-required-labels@v3
+      - uses: mheap/github-action-required-labels@v4
         with:
           mode: minimum
           count: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.8", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["pypy3.9", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
@@ -21,6 +21,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
           cache: pip
           cache-dependency-path: pyproject.toml
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,20 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+    rev: v3.4.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
 
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
       - id: black
-        args: [--target-version=py37]
 
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.13.0
     hooks:
       - id: blacken-docs
-        args: [--target-version=py37]
-        additional_dependencies: [black==22.12.0]
+        additional_dependencies: [black==23.3.0]
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
@@ -28,7 +26,8 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
-        additional_dependencies: [flake8-2020, flake8-implicit-str-concat]
+        additional_dependencies:
+          [flake8-2020, flake8-errmsg, flake8-implicit-str-concat]
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
@@ -39,38 +38,38 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-      - id: check-json
+      - id: check-case-conflict
       - id: check-merge-conflict
+      - id: check-json
       - id: check-toml
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.3.0
     hooks:
       - id: mypy
-        additional_dependencies: [pytest==7.2.0]
+        additional_dependencies: [pytest==7.3.1]
         args: [--strict, --pretty, --show-error-codes]
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: 0.9.2
+    rev: 0.10.0
     hooks:
       - id: pyproject-fmt
 
   - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.12.2
+    rev: v0.13
     hooks:
       - id: validate-pyproject
 
-  # Skip whilst it strips comments
-  #  - repo: https://github.com/tox-dev/tox-ini-fmt
-  #    rev: 0.5.0
-  #    hooks:
-  #      - id: tox-ini-fmt
+  - repo: https://github.com/tox-dev/tox-ini-fmt
+    rev: 1.3.0
+    hooks:
+      - id: tox-ini-fmt
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.6
+    rev: v3.0.0-alpha.9-for-vscode
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,29 +20,28 @@ keywords = [
 ]
 license = {text = "MIT"}
 authors = [{name = "Hugo van Kemenade"}]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
-    "Natural Language :: English",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
-    "Topic :: Artistic Software",
-    "Topic :: Text Processing",
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Natural Language :: English",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: Implementation :: CPython",
+  "Programming Language :: Python :: Implementation :: PyPy",
+  "Topic :: Artistic Software",
+  "Topic :: Text Processing",
 ]
 dynamic = [
   "version",
 ]
 dependencies = [
-  'importlib-metadata; python_version < "3.8"',
   'pyperclip; platform_system != "Linux"',
 ]
 [project.optional-dependencies]
@@ -63,9 +62,6 @@ version.source = "vcs"
 
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
-
-[tool.black]
-target_version = ["py37"]
 
 [tool.isort]
 profile = "black"

--- a/src/slackabet/__init__.py
+++ b/src/slackabet/__init__.py
@@ -1,15 +1,9 @@
 from __future__ import annotations
 
+import importlib.metadata
 import random
 
-try:
-    # Python 3.8+
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # Python 3.7 and lower
-    import importlib_metadata  # type: ignore
-
-__version__: str = importlib_metadata.version(__name__)
+__version__: str = importlib.metadata.version(__name__)
 
 
 COLOURS = ["white", "yellow"]
@@ -22,10 +16,6 @@ def slackabet(text: str, colour: str = "white") -> str:
         words = text.split()
         converted = []
         for i, word in enumerate(words):
-            if i % 2 == 0:
-                colour = "white"
-            else:
-                colour = "yellow"
             colour = "white" if i % 2 == 0 else "yellow"
 
             converted.append(slackabet(word, colour))

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,17 @@
 [tox]
-envlist =
+requires =
+    tox>=4.2
+env_list =
     lint
-    py{py3, 312, 311, 310, 39, 38, 37}
-isolated_build = true
+    py{py3, 312, 311, 310, 39, 38}
 
 [testenv]
 extras =
     tests
-passenv =
+pass_env =
     FORCE_COLOR
 commands =
-    # Unit tests
     {envpython} -m pytest --cov slackabet --cov tests --cov-report xml {posargs}
-
-    # Test runs
     slackabet --version
     slackabet --help
     slackabet abcdef
@@ -22,10 +20,10 @@ commands =
     sb uvwxyz
 
 [testenv:lint]
-passenv =
-    PRE_COMMIT_COLOR
 skip_install = true
 deps =
     pre-commit
+pass_env =
+    PRE_COMMIT_COLOR
 commands =
     pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
Changes proposed in this pull request:

 * Python 3.12 is in beta
 * Drop support for Python 3.7, EOL this month
   * https://devguide.python.org/versions/
   * https://peps.python.org/pep-0537/
 * Not planning a major bump, `requires-python = ">=3.8"` makes sure people get the right version
 * Publish to PyPI with a Trusted Publisher
   * https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
   * https://docs.pypi.org/trusted-publishers/
 * Also use https://github.com/hynek/build-and-inspect-python-package